### PR TITLE
Minecraft 1.20 & Horse teleportation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# intellij files
+/.idea/
+*.iml
+*.ipr
+*.iws
+
+# build
+/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-## Find the complete documentation for ZHorse on the wiki : https://github.com/Zedd7/ZHorse/wiki
+### Importance notice: We ([MiniCraftServer](https://github.com/minicraftserver)) will only maintain this project at a rudimentary level. We wont add new features. Feel free fork this project and maintain it properly. A big thank you to Z3dd7 for this amazing work!
+
+
+### Find the complete documentation for ZHorse on the wiki : https://github.com/Zedd7/ZHorse/wiki

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
 	        <id>vault-repo</id>
@@ -45,8 +45,8 @@
             <scope>provided</scope>
 		</dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>20</source>
+                    <target>20</target>
             	</configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,12 @@
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
-	        <id>vault-repo</id>
-	        <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <id>vault-repo</id>
+            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -35,23 +39,23 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.15.1</version>
             <scope>compile</scope>
         </dependency>
-    	<dependency>
-  			<groupId>mysql</groupId>
-  			<artifactId>mysql-connector-java</artifactId>
-  			<version>8.0.16</version>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
             <scope>provided</scope>
-		</dependency>
+        </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.github.zedd7</groupId>
     <artifactId>ZHorse</artifactId>
-    <version>1.8.2</version>
+    <version>1.8.4</version>
     <packaging>jar</packaging>
 
     <name>ZHorse</name>

--- a/src/main/java/com/github/zedd7/zhorse/enums/KeyWordEnum.java
+++ b/src/main/java/com/github/zedd7/zhorse/enums/KeyWordEnum.java
@@ -65,7 +65,7 @@ public enum KeyWordEnum {
 	TABLE_PREFIX("Databases.mysql-config.table-prefix"),
 	TP_MAX_RANGE("Settings.tp-max-range"),
 	TYPE("Databases.type"),
-	USE_OLD_TELEPORT_METHOD("Settings.use-old-teleport-method"),
+	USE_PAPERAPI_TELEPORT_METHOD("Settings.use-paperapi-teleport-method"),
 	USER("Databases.mysql-config.user"),
 	USE_DEFAULT_STABLE("Settings.use-default-stable"),
 	USE_EXACT_STATS("Settings.use-exact-stats"),

--- a/src/main/java/com/github/zedd7/zhorse/managers/ConfigManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/ConfigManager.java
@@ -292,7 +292,7 @@ public class ConfigManager {
 	}
 
 	public boolean shouldUsePaperAPITeleportMethod() {
-		return config.getBoolean(KeyWordEnum.USE_PAPERAPI_TELEPORT_METHOD.getValue(), false);
+		return config.getBoolean(KeyWordEnum.USE_PAPERAPI_TELEPORT_METHOD.getValue(), true);
 	}
 
 	public boolean shouldUseDefaultStable() {

--- a/src/main/java/com/github/zedd7/zhorse/managers/ConfigManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/ConfigManager.java
@@ -291,8 +291,8 @@ public class ConfigManager {
 		return config.getBoolean(KeyWordEnum.USE_VANILLA_STATS.getValue(), true);
 	}
 
-	public boolean shouldUseOldTeleportMethod() {
-		return config.getBoolean(KeyWordEnum.USE_OLD_TELEPORT_METHOD.getValue(), false);
+	public boolean shouldUsePaperAPITeleportMethod() {
+		return config.getBoolean(KeyWordEnum.USE_PAPERAPI_TELEPORT_METHOD.getValue(), false);
 	}
 
 	public boolean shouldUseDefaultStable() {

--- a/src/main/java/com/github/zedd7/zhorse/managers/EventManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/EventManager.java
@@ -156,7 +156,7 @@ public class EventManager implements Listener {
 	public void onEntityPortal(EntityPortalEvent e) {
 		if (e.getEntity() instanceof AbstractHorse) {
 			AbstractHorse horse = (AbstractHorse) e.getEntity();
-			if (!zh.getCM().shouldUsePaperAPITeleportMethod() && zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
+			if (zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
 				e.setCancelled(true);
 				Location destination = e.getTo();
 				if (zh.getCM().isWorldCrossable(destination.getWorld())) {
@@ -170,7 +170,7 @@ public class EventManager implements Listener {
 	public void onEntityTeleport(EntityTeleportEvent e) {
 		if (e.getEntity() instanceof AbstractHorse) {
 			AbstractHorse horse = (AbstractHorse) e.getEntity();
-			if (zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
+			if (!zh.getCM().shouldUsePaperAPITeleportMethod() && zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
 				e.setCancelled(true);
 				if (zh.getCM().isWorldEnabled(e.getTo().getWorld())) {
 					zh.getHM().teleportHorse(horse, e.getTo(), true);

--- a/src/main/java/com/github/zedd7/zhorse/managers/EventManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/EventManager.java
@@ -156,7 +156,7 @@ public class EventManager implements Listener {
 	public void onEntityPortal(EntityPortalEvent e) {
 		if (e.getEntity() instanceof AbstractHorse) {
 			AbstractHorse horse = (AbstractHorse) e.getEntity();
-			if (zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
+			if (!zh.getCM().shouldUsePaperAPITeleportMethod() && zh.getDM().isHorseRegistered(horse.getUniqueId(), true, null)) {
 				e.setCancelled(true);
 				Location destination = e.getTo();
 				if (zh.getCM().isWorldCrossable(destination.getWorld())) {

--- a/src/main/java/com/github/zedd7/zhorse/managers/HorseManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/HorseManager.java
@@ -196,8 +196,8 @@ public class HorseManager {
 	}
 
 	public AbstractHorse teleportHorse(AbstractHorse sourceHorse, Location destination, boolean sync) {
-		if (zh.getCM().shouldUseOldTeleportMethod()) {
-			sourceHorse.teleport(destination);
+		if (zh.getCM().shouldUsePaperAPITeleportMethod()) {
+			sourceHorse.teleportAsync(destination);
 			zh.getDM().updateHorseLocation(sourceHorse.getUniqueId(), destination, false, false, null);
 			return sourceHorse;
 		}

--- a/src/main/java/com/github/zedd7/zhorse/managers/HorseManager.java
+++ b/src/main/java/com/github/zedd7/zhorse/managers/HorseManager.java
@@ -49,102 +49,18 @@ public class HorseManager {
 		return getHorse(playerUUID, zh.getDM().getPlayerFavoriteHorseID(playerUUID, true, null));
 	}
 
+	public AbstractHorse getHorse(UUID horseUUID){
+		return (AbstractHorse) zh.getServer().getEntity(horseUUID);
+	}
+
 	public AbstractHorse getHorse(UUID playerUUID, Integer horseID) {
 		AbstractHorse horse = null;
 		if (playerUUID != null && horseID != null) {
 			UUID horseUUID = zh.getDM().getHorseUUID(playerUUID, horseID, true, null);
-			HorseRecord horseRecord = zh.getDM().getHorseRecord(horseUUID, true, null);
-			horse = getHorse(horseRecord);
+			horse = getHorse(horseUUID);
 		}
 		return horse;
 	}
-
-	public AbstractHorse getHorse(HorseRecord horseRecord) {
-		AbstractHorse horse = null;
-		if (horseRecord != null) {
-			UUID horseUUID = UUID.fromString(horseRecord.getUUID());
-			if (isHorseTracked(horseUUID)) {
-				horse = getTrackedHorse(horseUUID);
-			}
-			else {
-				Location location = new Location(
-						zh.getServer().getWorld(horseRecord.getLocationWorld()),
-						horseRecord.getLocationX(),
-						horseRecord.getLocationY(),
-						horseRecord.getLocationZ()
-				);
-				horse = getHorseFromLocation(horseUUID, location);
-				if (horse != null) {
-					boolean hasMoved = (
-						horse.getLocation().getBlockX() != location.getBlockX() ||
-						horse.getLocation().getBlockY() != location.getBlockY() ||
-						horse.getLocation().getBlockZ() != location.getBlockZ()
-					);
-					if (hasMoved) {
-						zh.getDM().updateHorseLocation(horseUUID, horse.getLocation(), false, false, null);
-					}
-				}
-				else if (zh.getCM().shouldRespawnMissingHorse()) {
-					HorseInventoryRecord inventoryRecord = zh.getDM().getHorseInventoryRecord(horseUUID, true, null);
-					HorseStatsRecord statsRecord = zh.getDM().getHorseStatsRecord(horseUUID, true, null);
-					if (inventoryRecord != null && statsRecord != null) { // Do not spawn if exact copy is impossible
-						horse = spawnHorse(location, inventoryRecord, statsRecord, true, horseUUID, horseRecord.getId(), horseRecord.getName());
-					}
-				}
-			}
-		}
-		return horse;
-	}
-
-	private AbstractHorse getHorseFromLocation(UUID horseUUID, Location location) {
-		AbstractHorse horse = null;
-		if (location != null) {
-			horse = getHorseInChunk(horseUUID, location.getChunk());
-			if (horse == null) {
-				List<Chunk> neighboringChunks = getChunksInRegion(location, 2, false);
-				horse = getHorseInRegion(horseUUID, neighboringChunks);
-			}
-		}
-		return horse;
-	}
-
-	private List<Chunk> getChunksInRegion(Location center, int chunkRange, boolean includeCentralChunk) {
-		World world = center.getWorld();
-		Location NWCorner = new Location(world, center.getX() - 16 * chunkRange, 0, center.getZ() - 16 * chunkRange);
-		Location SECorner = new Location(world, center.getX() + 16 * chunkRange, 0, center.getZ() + 16 * chunkRange);
-		List<Chunk> chunkList = new ArrayList<Chunk>();
-		for (int x = NWCorner.getBlockX(); x <= SECorner.getBlockX(); x += 16) {
-			for (int z = NWCorner.getBlockZ(); z <= SECorner.getBlockZ(); z += 16) {
-				if (center.getBlockX() != x || center.getBlockZ() != z || includeCentralChunk) {
-					Location chunkLocation = new Location(world, x, 0, z);
-					Chunk chunk = world.getChunkAt(chunkLocation); // w.getChunkAt(x, z) uses chunk coordinates (loc / 16)
-					chunkList.add(chunk);
-				}
-			}
-		}
-		return chunkList;
-	}
-
-	private AbstractHorse getHorseInChunk(UUID horseUUID, Chunk chunk) {
-		for (Entity entity : chunk.getEntities()) {
-			if (entity.getUniqueId().equals(horseUUID)) {
-				return (AbstractHorse) entity;
-			}
-		}
-		return null;
-	}
-
-	private AbstractHorse getHorseInRegion(UUID horseUUID, List<Chunk> region) {
-		AbstractHorse horse = null;
-		for (Chunk chunk : region) {
-			horse = getHorseInChunk(horseUUID, chunk);
-			if (horse != null) {
-				return horse;
-			}
-		}
-		return horse;
-	}
-
 	public AbstractHorse getTrackedHorse(UUID horseUUID) {
 		return trackedHorses.get(horseUUID);
 	}

--- a/src/main/java/com/github/zedd7/zhorse/utils/ConfigValidator.java
+++ b/src/main/java/com/github/zedd7/zhorse/utils/ConfigValidator.java
@@ -212,7 +212,7 @@ public class ConfigValidator extends YamlResourceValidator {
 			}
 			validateOptionSet(KeyWordEnum.USE_EXACT_STATS.getValue());
 			validateOptionSet(KeyWordEnum.USE_VANILLA_STATS.getValue());
-			validateOptionSet(KeyWordEnum.USE_OLD_TELEPORT_METHOD.getValue());
+			validateOptionSet(KeyWordEnum.USE_PAPERAPI_TELEPORT_METHOD.getValue());
 			validateOptionSet(KeyWordEnum.USE_DEFAULT_STABLE.getValue());
 			validateOptionSet(KeyWordEnum.SEND_TO_STABLE_ON_OWNER_LOGOUT.getValue());
 			validateOptionSet(KeyWordEnum.DEFAULT_STABLE_LOCATION_WORLD.getValue());

--- a/src/main/java/com/github/zedd7/zhorse/utils/MessageConfig.java
+++ b/src/main/java/com/github/zedd7/zhorse/utils/MessageConfig.java
@@ -5,6 +5,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import com.github.zedd7.zhorse.enums.LocaleEnum;
 
@@ -150,10 +151,7 @@ public class MessageConfig {
 				flagContent = numberFormatter.format(token);
 			}
 			else {
-				if(token != null)
-					flagContent = token.toString();
-				else
-					flagContent = "";
+				flagContent = Objects.toString(token, "");
 			}
 			flagContentList.add(flagContent);
 		}

--- a/src/main/java/com/github/zedd7/zhorse/utils/MessageConfig.java
+++ b/src/main/java/com/github/zedd7/zhorse/utils/MessageConfig.java
@@ -150,7 +150,10 @@ public class MessageConfig {
 				flagContent = numberFormatter.format(token);
 			}
 			else {
-				flagContent = token.toString();
+				if(token != null)
+					flagContent = token.toString();
+				else
+					flagContent = "";
 			}
 			flagContentList.add(flagContent);
 		}

--- a/src/main/java/com/github/zedd7/zhorse/utils/PlayerQuit.java
+++ b/src/main/java/com/github/zedd7/zhorse/utils/PlayerQuit.java
@@ -33,7 +33,7 @@ public class PlayerQuit {
 
 									@Override
 									public void callback(CallbackResponse<Location> response) {
-										AbstractHorse horse = zh.getHM().getHorse(horseRecord);
+										AbstractHorse horse = zh.getHM().getHorse(horseUUID);
 										if (horse != null && (!horse.isLeashed() || !blockLeashedTeleport)) {
 											Location stableLocation = response.getResult();
 											if (stableLocation != null && zh.getCM().isWorldCrossable(stableLocation.getWorld())) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: ${description}
 website: ${url}
 author: ${author}
 main: ${main-class}
-api-version: 1.14
+api-version: 1.20
 
 commands:
   zhorse:

--- a/src/main/resources/yaml/config.yml
+++ b/src/main/resources/yaml/config.yml
@@ -368,9 +368,10 @@ Settings:
   # Does not affect actual horse stats, only applies to /zh spawn and /zh info.
   use-vanilla-stats: true
 
-  # Set to false to switch to the custom teleport method provided by ZHorse
-  # The custom method will removes horses and respawns them at destination
-  # Keep it on true to use the async teleportation method provided by the PaperAPI
+  # ZHorse offers a custom teleportation method. When set to false, it removes
+  # the horse from its current location, clones it, and respawns it at
+  # the targeted teleport location.
+  # Set to true for asynchronous teleportation using the paperapi provided method.
   use-paperapi-teleport-method: true
   
   # Set to true to use the location defined by default-stable-location for

--- a/src/main/resources/yaml/config.yml
+++ b/src/main/resources/yaml/config.yml
@@ -368,11 +368,10 @@ Settings:
   # Does not affect actual horse stats, only applies to /zh spawn and /zh info.
   use-vanilla-stats: true
 
-  # Set to true to switch to the teleportation method used in ZHorse 1.4-.
-  # This is only recommended for servers using plugins that are
-  # incompatible with the new ZHorse 1.5+ teleportation method.
-  # The new method removes horses and respawns them at destination.
-  use-old-teleport-method: false
+  # Set to false to switch to the custom teleport method provided by ZHorse
+  # The custom method will removes horses and respawns them at destination
+  # Keep it on true to use the async teleportation method provided by the PaperAPI
+  use-paperapi-teleport-method: true
   
   # Set to true to use the location defined by default-stable-location for
   # horses whose stable has not been defined when using /zh stable go or


### PR DESCRIPTION
- Update all dependencies
- Rebrand the config option `use-old-teleport-method` to `use-paperapi-teleport-method` and change it accordingly to papers asyncTeleport method
- Fix StackOverflow when using the PaperAPI method
- Fix NPE when token is null in MessageConfig's getFlagContentList method